### PR TITLE
no chrome-update shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "description": "Turbocharge lichess.org with a ton of features",
   "author": "costin.manda@siderite.dev",
   "homepage_url": "https://siderite.dev/blog/new-chrome-extension-lichess-tools/",
-  "minimum_chrome_version": "111",
+  "minimum_chrome_version": "1",
   "icons": {
     "16": "images/icon-16.png",
     "19": "images/icon-19.png",


### PR DESCRIPTION
if you fill in the blank i can make another PR or commit like:    `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    (or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)