### PR TITLE
Lichess Tools preferences fix

### DIFF
--- a/tools/preferences/tool.css
+++ b/tools/preferences/tool.css
@@ -1,11 +1,7 @@
 /* CSS in preferences should not be under body.lichessTools, as the class can be removed when the extension is disabled */
 
-a + a.lichessTools-preferences {
-  margin-left: 1em;
-}
-
 a.lichessTools-preferences:before {
-  font-size: 0.9em;
+  font-size: 1.2em;
   text-shadow: var(--c-clearer) 1px 0 7px;
 }
 

--- a/tools/preferences/tool.css
+++ b/tools/preferences/tool.css
@@ -2,7 +2,8 @@
 
 a.lichessTools-preferences:before {
   font-size: 1.2em;
-  text-shadow: var(--c-clearer) 1px 0 7px;
+  text-shadow: var(--c-accent-dim) 1px 0 7px;
+  color: var(--c-accent);
 }
 
 div.lichessTools-preferences .lichessTools-prefCount {


### PR DESCRIPTION
The current menu item in the profile dropdown is broken (Refer screenshot)
![image](https://github.com/user-attachments/assets/505a312c-af55-47fe-952b-ec4bce25829e)

This PR fixes the above issue by removing the css that's breaking. 
Tested on all resolutions.

Also added accent color to the lichess tools icon.