### PR TITLE
Small improvements to game count feature

### DIFF
--- a/tools/showGameCount/tool.js
+++ b/tools/showGameCount/tool.js
@@ -41,7 +41,7 @@
       // Process user links
       $.cached('.user-link,a[href^="/@/"]', 2000).each((i, e) => {
         // Skip elements in excluded areas (friend list, chat, nav, etc.)
-        if ($(e).closest('#friend_box,.lichessTools-onlineFriends,div.complete-list,.crosstable__users,div.chat__members,#dasher_app,.lichessTools-challengeOptions,#topnav,.ublog-post__meta').length) return;
+        if ($(e).closest('#friend_box,.lichessTools-onlineFriends,div.complete-list,.crosstable__users,div.chat__members,#dasher_app,.lichessTools-challengeOptions,#topnav,.ublog-post__meta,.mchat__messages').length) return;
 
         // Find the text element within the link
         let textEl = $('.text', e);


### PR DESCRIPTION
Three small improvements to the "game counts" implementation:

1. filter out puzzles from the total game count

2. skip adding game count label to in-game chat box messages

3. clarify messages to indicate that this only counts rated games (as far as I can tell, casual games are not available in the API response used currently)

Sorry I didn't notice the puzzles thing earlier... I spot checked the initial implementation with a few accounts, but from those it wasn't apparent.