### PR TITLE
fix: add all/none controls for bot type filters

### DIFF
--- a/tools/botFilters/tool.css
+++ b/tools/botFilters/tool.css
@@ -38,6 +38,10 @@ body.lichessTools .lichessTools-botFilters input[type="number"] {
   max-width: 7em;
 }
 
+body.lichessTools .lichessTools-botFilters .types button {
+  margin-right: 0.5em;
+}
+
 /* Lichess Helper CSS */
 
 

--- a/tools/botFilters/tool.js
+++ b/tools/botFilters/tool.js
@@ -22,7 +22,9 @@
         'gamesLabelText': 'Games min/max', 
         'gamesLabelTitle': 'LiChess Tools - min/max games', 
         'gameTypesLabelText': 'Game types', 
-        'gameTypesLabelTitle': 'LiChess Tools - game types'
+        'gameTypesLabelTitle': 'LiChess Tools - game types',
+        'allTypesText': 'all',
+        'noneTypesText': 'none'
       },
       'ro-RO': {
         'options.general': 'General',
@@ -33,7 +35,9 @@
         'gamesLabelText': 'Meciuri min/max', 
         'gamesLabelTitle': 'LiChess Tools - meciuri min/max', 
         'gameTypesLabelText': 'Tipuri de joc', 
-        'gameTypesLabelTitle': 'LiChess Tools - tipuri de joc'
+        'gameTypesLabelTitle': 'LiChess Tools - tipuri de joc',
+        'allTypesText': 'toate',
+        'noneTypesText': 'nimic'
       }
     }
 
@@ -89,6 +93,8 @@
            </fieldset>
            <fieldset class="types">
              <legend></legend>
+             <button type="button" class="lichessTools-botTypesAll"></button>
+             <button type="button" class="lichessTools-botTypesNone"></button>
            </fieldset>
          </div>`)
         .prependTo('.bots.page-menu__content');
@@ -104,6 +110,18 @@
       $('.types legend',container)
         .text(trans.noarg('gameTypesLabelText'))
         .attr('title',trans.noarg('gameTypesLabelTitle'));
+      $('.lichessTools-botTypesAll',container)
+        .text(trans.noarg('allTypesText'))
+        .on('click',()=>{
+          $('.types input[data-icon]',container).prop('checked',true);
+          this.filterBots();
+        });
+      $('.lichessTools-botTypesNone',container)
+        .text(trans.noarg('noneTypesText'))
+        .on('click',()=>{
+          $('.types input[data-icon]',container).prop('checked',false);
+          this.filterBots();
+        });
       const order = [
         lt.icon.UltraBullet,
         lt.icon.Bullet,


### PR DESCRIPTION
## Bug
Fixes #1562 — the bot type filters only allowed one-by-one toggling, making it cumbersome to clear all filters or restore all filters quickly.

## Fix
- Added `all` and `none` controls in the bot type filters panel
- Wired both controls to toggle every type checkbox in one action
- Triggered existing filtering logic immediately after each bulk toggle
- Added translated button labels for English and Romanian

## Testing
- Open `/player/bots`
- Use the new `all` / `none` buttons in the Game types filter group
- Verify bot entries update immediately based on the selected set

Happy to address any feedback.

Greetings, saschabuehrle
