### PR TITLE
Format hover time controls

### DIFF
--- a/tools/themes/context.md
+++ b/tools/themes/context.md
@@ -40,7 +40,7 @@ When themes selected: CSS classes `lichessTools-theme_<themeName>` added to body
 | adamisko | Vintage Adamisko |
 | arcade | Arcade (requires Board Styling) |
 | fixThirdParties | Fix third parties |
-| timeControls | Hover time controls |
+| timeControls | Hover time controls, formatted in minutes (for example, `60+1` is shown as `1+1` and `15+0` as `¼+0`) |
 | firstInteraction | First interaction |
 | noVariants | No chess variants |
 | noBullet | Hide Bullet chess |

--- a/tools/themes/timeControls.css
+++ b/tools/themes/timeControls.css
@@ -1,13 +1,13 @@
 /* Time controls */
 
-body.lichessTools.lichessTools-theme_timeControls #powerTip:has(a[data-tc]),
-body.lichessTools.lichessTools-theme_timeControls #miniGame:has(a[data-tc]) {
+body.lichessTools.lichessTools-theme_timeControls #powerTip:has(a[data-tc-label]),
+body.lichessTools.lichessTools-theme_timeControls #miniGame:has(a[data-tc-label]) {
   overflow:visible;
 }
 
-body.lichessTools.lichessTools-theme_timeControls #powerTip a[data-tc]:after,
-body.lichessTools.lichessTools-theme_timeControls #miniGame a[data-tc]:after {
-  content: attr(data-tc);
+body.lichessTools.lichessTools-theme_timeControls #powerTip a[data-tc-label]:after,
+body.lichessTools.lichessTools-theme_timeControls #miniGame a[data-tc-label]:after {
+  content: attr(data-tc-label);
   top: -1.5em;
   right: 0;
   position: absolute;

--- a/tools/themes/tool.js
+++ b/tools/themes/tool.js
@@ -203,6 +203,7 @@
         }
 
         this.toggleFlairX();
+        this.toggleTimeControls();
       } finally {
         this._inApplyThemes = false;
       }
@@ -353,6 +354,50 @@
       if (enabled) {
         document.addEventListener("pointerenter",this.flairEnter , true);
       }
+    };
+
+    formatTimeControl = timeControl => {
+      const match = /^(\d+)(\+\d+)?$/.exec(timeControl);
+      if (!match) return timeControl;
+      const seconds = +match[1];
+      const minutes = Math.floor(seconds / 60);
+      const fraction = {
+        0: '',
+        15: '\u00bc',
+        30: '\u00bd',
+        45: '\u00be'
+      }[seconds % 60];
+      if (fraction === undefined) return timeControl;
+      const initial = minutes
+        ? minutes + fraction
+        : fraction || '0';
+      return initial + (match[2] || '');
+    };
+
+    setTimeControlLabels = () => {
+      const lt = this.lichessTools;
+      const $ = lt.$;
+      $('#powerTip a[data-tc],#miniGame a[data-tc]').each((i, e) => {
+        $(e).attr('data-tc-label', this.formatTimeControl($(e).attr('data-tc')));
+      });
+    };
+
+    toggleTimeControls = () => {
+      const lt = this.lichessTools;
+      const $ = lt.$;
+      const selector = '#powerTip,#miniGame,#powerTip *,#miniGame *';
+      $('body').observer().off(selector, this.setTimeControlLabels);
+      if (!(`,${this.themes || ''},`.includes(',timeControls,'))) {
+        $('#powerTip a[data-tc-label],#miniGame a[data-tc-label]').removeAttr('data-tc-label');
+        return;
+      }
+      $('body').observer().on(selector, this.setTimeControlLabels, {
+        attributes: true,
+        attributeFilter: ['data-tc'],
+        characterData: false,
+        executeDirect: true
+      });
+      this.setTimeControlLabels();
     };
 
     async start() {


### PR DESCRIPTION
Display Lichess-style values such as 1+1 and ¼+0 while preserving the original seconds-based data attribute.

Fixes #1770 