### PR TITLE
Fix problems for Orion browser

### DIFF
--- a/scripts/lichessTools-comm-proxy.js
+++ b/scripts/lichessTools-comm-proxy.js
@@ -1,13 +1,71 @@
+const handleLocally = async (detail) => {
+  switch (detail?.type) {
+    case 'getFile': {
+      const filename = detail.options?.filename;
+      if (!filename) return;
+      const response = await fetch(chrome.runtime.getURL(filename));
+      if (!response.ok) return;
+      return await response.json();
+    }
+    case 'fetchText': {
+      const { url, retries, ...options } = detail.options || {};
+      if (!url) return;
+      const response = await fetch(url,options);
+      if (!response.ok) return;
+      return { text: await response.text() };
+    }
+    case 'getVersion': {
+      return { version: chrome.runtime.getManifest().version };
+    }
+    case 'getChromeUrl': {
+      return { url: chrome.runtime.getURL(detail.options?.url) };
+    }
+  }
+};
+
+const sendToBackground = (detail) => {
+  return new Promise((resolve,reject) => {
+    const pointer = globalThis.setTimeout(()=>reject(new Error('Background response timeout')),3000);
+    Promise.resolve(chrome.runtime.sendMessage(detail)).then(response=>{
+      globalThis.clearTimeout(pointer);
+      resolve(response);
+    },e=>{
+      globalThis.clearTimeout(pointer);
+      reject(e);
+    });
+  });
+};
+
 window.addEventListener('LichessTools.send', async (ev) => {
   const extensionId = chrome?.runtime?.id;
   if (!extensionId) return;
-  const uid = ev.detail.uid;
-  const response = await chrome.runtime.sendMessage(ev.detail);
-  if (chrome.runtime.lastError) globalThis.console.warn('Error sending message:', chrome.runtime.lastError);
-  let newDetail={ ...response, uid: uid };
-  if (globalThis.cloneInto) {
-    newDetail=cloneInto(newDetail,document.defaultView);
+  let detail;
+  try {
+    detail = typeof ev.detail == 'string'
+      ? JSON.parse(ev.detail)
+      : ev.detail;
+  } catch (e) {
+    globalThis.console.warn('Could not parse extension request:',e);
+    return;
   }
+  const uid = detail?.uid;
+  if (!uid) return;
+  let response;
+  try {
+    response = await sendToBackground(detail);
+    if (!response || response.err) {
+      response = await handleLocally(detail) || response;
+    }
+  } catch (e) {
+    globalThis.console.warn('Error sending message:',e);
+    try {
+      response = await handleLocally(detail);
+    } catch (localError) {
+      globalThis.console.warn('Error handling message locally:',localError);
+      response = { err: localError.toString() };
+    }
+  }
+  const newDetail=JSON.stringify({ ...response, uid: uid });
   const customEvent = new CustomEvent("LichessTools.receive", {
     detail: newDetail,
     bubbles: true,

--- a/scripts/lichessTools-comm.js
+++ b/scripts/lichessTools-comm.js
@@ -10,10 +10,19 @@
       init() {
         const lt = this.lichessTools;
         lt.global.addEventListener('LichessTools.receive', (ev) => {
-          const sendResponse = this.sendResponses[ev.detail.uid];
+          let detail;
+          try {
+            detail = typeof ev.detail == 'string'
+              ? JSON.parse(ev.detail)
+              : ev.detail;
+          } catch (e) {
+            lt.global.console.warn('Could not parse extension response',e);
+            return;
+          }
+          const sendResponse = this.sendResponses[detail?.uid];
           if (sendResponse) {
-            delete this.sendResponses[ev.detail.uid];
-            sendResponse(ev.detail);
+            delete this.sendResponses[detail.uid];
+            sendResponse(detail);
           }
         });
         lt.cache.memoizeAsyncFunction(lt.comm, 'getDataUrl', { persist: 'session', interval: 1 * 86400 * 1000, resultFilter: (r)=>r?.dataUrl });
@@ -35,7 +44,8 @@
           };
           this.sendResponses[uid] = f;
           const customEvent = new CustomEvent("LichessTools.send", {
-            detail: { ...data, uid: uid },
+            // Strings can safely cross Firefox's page/content-script boundary.
+            detail: JSON.stringify({ ...data, uid: uid }),
             bubbles: true,
             cancelable: true,
             composed: false,


### PR DESCRIPTION
Here are the problems I encountered in both the desktop and mobile versions of Orion when using the Firefox version from the store. Using the Chrome version fixes all the issues below on desktop, but not on mobile:

- Custom pieces provided by Lichess Tools are not displayed.
- Custom sounds provided by Lichess Tools cannot be selected.
- Evaluations are not displayed in the explorer, either from ChessDB or the local evaluation.
- The custom Lichess Ladders page is not displayed.

I described the problem to an LLM and tried its solution, even though I didn’t fully understand the code it generated. Here’s how I tested it:

1. Ran `cp manifest.json.ff manifest.json`.
2. Created a ZIP archive containing everything in the current directory.
3. Installed it from the ZIP file as a custom add-on in Orion on desktop.

I followed these steps both before and after applying the fix. I confirmed that the previous version still had all the issues listed above, while the fixed version resolved all of them.

related: #1444 